### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-03-24
+
+### Enhanced
+
+- 🛡️ **gRPC Client SSL/TLS Bypass** - Added `verify` parameter to `GrpcClient` (defaults to `True`). Setting `verify=False` automatically fetches and trusts self-signed certificates, providing an experience identical to `grpcurl -insecure`.
+- 🔌 **gRPC ALPN Subprotocols** - Added HTTP/2 (h2) ALPN declaration to the underlying certificate extraction socket to support strict Load Balancers and proxies like Envoy and Nginx.
+- 🌐 **gRPC Native DNS Resolver** - Built-in automatic fallback to `GRPC_DNS_RESOLVER=native` to resolve `c-ares` DNS resolution failures on macOS and VPN environments.
+
 ## [0.5.0] - 2026-03-16
 
 ### Added
@@ -220,6 +228,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable attachment size limits
 - Professional report styling with responsive design
 
+[0.5.1]: https://github.com/o73k51i/qapytest/releases/tag/v0.5.1
 [0.5.0]: https://github.com/o73k51i/qapytest/releases/tag/v0.5.0
 [0.4.0]: https://github.com/o73k51i/qapytest/releases/tag/v0.4.0
 [0.3.6]: https://github.com/o73k51i/qapytest/releases/tag/v0.3.6

--- a/docs/Clients.md
+++ b/docs/Clients.md
@@ -272,6 +272,7 @@ GrpcClient(
     timeout: float = 10.0,
     name_logger: str = "GrpcClient",
     enable_log: bool = True,
+    verify: bool = True,
     **kwargs,
 )
 ```
@@ -281,6 +282,8 @@ GrpcClient(
 - Support for both reflection (automatic discovery) and compiled python stubs
 - Automatic and structured logging for each request and response
 - Execution time tracking and error details logging
+- `verify=False` flag to automatically bypass SSL verification on test environments (similar to `grpcurl -insecure`)
+- Native DNS fallback automatically enabled under the hood for VPNs and macOS compatibility
 - Context manager support and proper connection closing
 
 ### Installation
@@ -301,16 +304,27 @@ pip install "qapytest[grpc]"
 ```python
 from qapytest import GrpcClient
 
-# 1. With Reflection:
-client = GrpcClient(base_url="localhost:50051", enable_log=True)
+# 1. Plaintext connection (without SSL, typically local development like `grpcurl -plaintext`)
+client_local = GrpcClient(
+    base_url="localhost:50051", 
+    ssl=False, 
+    enable_log=True
+)
+
+# 2. With SSL and Certificate Bypass (for test environments like `grpcurl -insecure`)
+client = GrpcClient(
+    base_url="test.lan:443",
+    verify=False,
+    enable_log=True
+)
 response = client.request("helloworld.Greeter", "SayHello", {"name": "QA"})
 print(response)
 
-# 2. Without Reflection (with compiled python stubs):
+# 3. Without Reflection (with compiled python stubs):
 import helloworld_pb2
 
 client_stub = GrpcClient(
-    base_url="localhost:50051",
+    base_url="prod.com:443", # verify=True by default for production
     pb2_modules=[helloworld_pb2],
 )
 response = client_stub.request("helloworld.Greeter", "SayHello", {"name": "QA"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qapytest"
-version = "0.5.0"
+version = "0.5.1"
 description = "A powerful testing framework based on pytest, specifically designed for QA engineers"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/qapytest/_client_grpc.py
+++ b/qapytest/_client_grpc.py
@@ -2,10 +2,15 @@
 
 import json
 import logging
+import os
+import socket
+import ssl
 import time
 from typing import Any
 
 from qapytest._config import AnyType
+
+os.environ.setdefault("GRPC_DNS_RESOLVER", "native")
 
 try:
     import grpc
@@ -14,6 +19,21 @@ try:
 except ImportError as e:
     msg = "The 'grpc' package is required to use gRPC client. Install it with: pip install \"qapytest[grpc]\""
     raise ImportError(msg) from e
+
+
+def _get_server_certificate(host: str, port: int) -> bytes:
+    """Fetch the server certificate without verification."""
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    with (
+        socket.create_connection((host, port)) as sock,
+        context.wrap_socket(sock, server_hostname=host) as ssock,
+    ):
+        cert = ssock.getpeercert(binary_form=True)
+        if not cert:
+            raise ValueError(f"Could not get certificate for {host}:{port}")
+    return ssl.DER_cert_to_PEM_cert(cert).encode("utf-8")
 
 
 class GrpcClient:
@@ -31,6 +51,8 @@ class GrpcClient:
         timeout: Default timeout in seconds for all requests. Default is 10.0.
         name_logger: Name of the logger to use. Default is "GrpcClient".
         enable_log: Whether to log requests and responses. Default is True.
+        verify: Verify SSL certificates. If False, bypasses validation like
+                `grpcurl -insecure`. Default is True.
         **kwargs: Additional arguments passed to the underlying `grpc_requests.Client`.
 
     ---
@@ -57,6 +79,7 @@ class GrpcClient:
         timeout: float = 10.0,
         name_logger: str = "GrpcClient",
         enable_log: bool = True,
+        verify: bool = True,
         **kwargs,
     ) -> None:
         """Constructor for GrpcClient."""
@@ -67,6 +90,19 @@ class GrpcClient:
         self.base_url = base_url
         self.timeout = timeout
         self.enable_log = enable_log
+
+        if not verify:
+            parts = base_url.split(":")
+            host = parts[0]
+            port = int(parts[1]) if len(parts) > 1 else 443
+            try:
+                pem = _get_server_certificate(host, port)
+                kwargs["ssl"] = True
+                if "credentials" not in kwargs:
+                    kwargs["credentials"] = {}
+                kwargs["credentials"]["root_certificates"] = pem
+            except Exception as e:
+                self._logger.warning(f"Failed to fetch certificate for verify=False: {e}")
 
         if pb2_modules:
             service_descriptors = []

--- a/qapytest/_client_grpc.py
+++ b/qapytest/_client_grpc.py
@@ -26,6 +26,7 @@ def _get_server_certificate(host: str, port: int) -> bytes:
     context = ssl.create_default_context()
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
+    context.set_alpn_protocols(["h2"])
     with (
         socket.create_connection((host, port)) as sock,
         context.wrap_socket(sock, server_hostname=host) as ssock,

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "qapytest"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "faker" },


### PR DESCRIPTION
### Enhanced

- 🛡️ **gRPC Client SSL/TLS Bypass** - Added `verify` parameter to `GrpcClient` (defaults to `True`). Setting `verify=False` automatically fetches and trusts self-signed certificates, providing an experience identical to `grpcurl -insecure`.
- 🔌 **gRPC ALPN Subprotocols** - Added HTTP/2 (h2) ALPN declaration to the underlying certificate extraction socket to support strict Load Balancers and proxies like Envoy and Nginx.
- 🌐 **gRPC Native DNS Resolver** - Built-in automatic fallback to `GRPC_DNS_RESOLVER=native` to resolve `c-ares` DNS resolution failures on macOS and VPN environments.