### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🌐 **HttpClient** - removed explicit `headers`, `verify`, and `timeout` parameters; they can now be passed directly via `**kwargs` for greater flexibility.
 - 📚 **Documentation** - updated HTTP client documentation to reflect the new `**kwargs` approach.
+- 📝 **README** - added JSON Query (`find_value`, `find_values`) to the key features section.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-20
+
+### Changed
+
+- 🌐 **HttpClient** - removed explicit `headers`, `verify`, and `timeout` parameters; they can now be passed directly via `**kwargs` for greater flexibility.
+- 📚 **Documentation** - updated HTTP client documentation to reflect the new `**kwargs` approach.
+
+### Fixed
+
+- 🧪 **Test updates** - updated test cases to align with the new `HttpClient` parameter interface.
+
 ## [0.6.0] - 2026-05-04
 
 ### Added
@@ -240,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable attachment size limits
 - Professional report styling with responsive design
 
+[0.6.1]: https://github.com/o73k51i/qapytest/releases/tag/v0.6.1
 [0.6.0]: https://github.com/o73k51i/qapytest/releases/tag/v0.6.0
 [0.5.1]: https://github.com/o73k51i/qapytest/releases/tag/v0.5.1
 [0.5.0]: https://github.com/o73k51i/qapytest/releases/tag/v0.5.0

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ debugging needs.
   data.
 - **JSON Schema validation:** function to validate API responses or test
   artifacts with support for soft-assert and strict mode.
+- **JSON Query:** lightweight query utilities (`find_value`, `find_values`) for
+  navigating and extracting data from nested JSON-like Python objects.
 - **Unicode support:** proper display of Unicode characters (Cyrillic, Arabic,
   Chinese, etc.) in terminal and HTML reports.
 

--- a/docs/Clients.md
+++ b/docs/Clients.md
@@ -19,16 +19,13 @@ HTTP client with automatic request/response logging and sensitive data masking.
 ```python
 HttpClient(
     base_url: str = "",
-    headers: dict[str, str] | None = None,
-    verify: bool = True,
-    timeout: float = 10.0,
     sensitive_headers: set[str] | None = None,
     sensitive_json_fields: set[str] | None = None,
     sensitive_text_patterns: list[str] | None = None,
     mask_sensitive_data: bool = True,
     name_logger: str = "HttpClient",
     enable_log: bool = True,
-    **kwargs,
+    **kwargs,  # e.g. headers=, timeout=, verify=, cookies=, proxies=
 ) → subclass of `httpx.Client`
 ```
 
@@ -53,8 +50,6 @@ from qapytest import HttpClient
 
 client = HttpClient(
     base_url="https://jsonplaceholder.typicode.com",
-    timeout=30,
-    headers={"Authorization": "Bearer token"},
     mask_sensitive_data=True,
     enable_log=True,
 )
@@ -71,16 +66,13 @@ Specialized client for GraphQL APIs with automatic logging and sensitive data ma
 ```python
 GraphQLClient(
     endpoint_url: str,
-    headers: dict[str, str] | None = None,
-    verify: bool = True,
-    timeout: float = 10.0,
     sensitive_headers: set[str] | None = None,
     sensitive_json_fields: set[str] | None = None,
     sensitive_text_patterns: list[str] | None = None,
     mask_sensitive_data: bool = True,
     name_logger: str = "GraphQLClient",
     enable_log: bool = True,
-    **kwargs,
+    **kwargs,  # e.g. headers=, timeout=, verify=, cookies=, proxies=
 ) # -> subclass of `httpx.Client`
 ```
 
@@ -109,9 +101,6 @@ from qapytest import GraphQLClient
 
 client = GraphQLClient(
     endpoint_url="https://spacex-production.up.railway.app/",
-    headers={"Authorization": "Bearer token"},
-    verify=True,
-    timeout=15.0,
     mask_sensitive_data=True,
     enable_log=True,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qapytest"
-version = "0.6.0"
+version = "0.6.1"
 description = "A powerful testing framework based on pytest, specifically designed for QA engineers"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/qapytest/_client_http.py
+++ b/qapytest/_client_http.py
@@ -22,11 +22,6 @@ class HttpClient(BaseHttpClient):
 
     Args:
         base_url: Base URL for all requests. Default is an empty string.
-        headers: Dictionary of headers for requests. Default is None.
-        verify: Whether to verify SSL certificates. Default is True.
-        timeout: Overall timeout for requests in seconds. Default is 10.0 seconds.
-        max_log_size: Maximum size in bytes for logged request/response bodies.
-                      Bodies larger than this will be truncated. Default is 1024 bytes.
         sensitive_headers: Set of header names to mask in logs.
                            If None, uses default sensitive headers.
         sensitive_json_fields: Set of JSON field names to mask in logs.
@@ -35,7 +30,7 @@ class HttpClient(BaseHttpClient):
         name_logger: Name of the logger to use for logging HTTP requests.
                      Default is "HttpClient".
         **kwargs: Additional arguments passed directly to the constructor of the base
-                 `httpx.Client` class (e.g., `headers`, `cookies`, `proxies`).
+                 `httpx.Client` class (e.g., `headers`, `timeout`, `verify`, `cookies`, `proxies`).
 
     ---
     ### Example usage:
@@ -64,9 +59,6 @@ class HttpClient(BaseHttpClient):
     def __init__(
         self,
         base_url: str = "",
-        headers: dict[str, str] | None = None,
-        verify: bool = True,
-        timeout: float = 10.0,
         sensitive_headers: set[str] | None = None,
         sensitive_json_fields: set[str] | None = None,
         sensitive_text_patterns: list[str] | None = None,
@@ -78,10 +70,6 @@ class HttpClient(BaseHttpClient):
 
         Args:
             base_url: Base URL for all requests. Default is an empty string.
-            headers: Dictionary of headers for requests. Default is None.
-            verify: Whether to verify SSL certificates. Default is True.
-            timeout: Overall timeout for requests in seconds.
-                     Default is 10.0 seconds.
             sensitive_headers: Set of header names to mask in logs. If None,
                                uses default sensitive headers.
             sensitive_json_fields: Set of JSON field names to mask in logs.
@@ -92,13 +80,11 @@ class HttpClient(BaseHttpClient):
                                  Default is True.
             name_logger: Name of the logger to use for logging HTTP requests.
                          Default is "HttpClient".
-            **kwargs: Standard arguments for the `httpx.Client` constructor.
+            **kwargs: Standard arguments for the `httpx.Client` constructor
+                      (e.g., `headers`, `timeout`, `verify`, `cookies`, `proxies`).
         """
         super().__init__(
             base_url=base_url,
-            headers=headers,
-            verify=verify,
-            timeout=timeout,
             sensitive_headers=sensitive_headers,
             sensitive_json_fields=sensitive_json_fields,
             sensitive_text_patterns=sensitive_text_patterns,
@@ -119,10 +105,6 @@ class GraphQLClient:
 
     Args:
         endpoint_url: The full URL of the GraphQL endpoint.
-        headers: Headers added to every request.
-        timeout: Overall timeout for responses in seconds.
-        max_log_size: Maximum size in bytes for logged request/response bodies.
-                      Default is 1024 bytes.
         sensitive_headers: Set of header names to mask in logs.
                            If None, uses default sensitive headers.
         sensitive_json_fields: Set of JSON field names to mask in logs.
@@ -131,7 +113,8 @@ class GraphQLClient:
                              Default is True.
         name_logger: Name of the logger to use for logging GraphQL requests.
                      Default is "GraphQLClient".
-        **kwargs: Other arguments passed directly to the `httpx.Client` constructor.
+        **kwargs: Other arguments passed directly to the `httpx.Client` constructor
+                  (e.g., `headers`, `timeout`, `verify`, `cookies`, `proxies`).
 
     ---
     ### Example usage:
@@ -176,9 +159,6 @@ class GraphQLClient:
     def __init__(
         self,
         endpoint_url: str,
-        headers: dict[str, str] | None = None,
-        verify: bool = True,
-        timeout: float = 10.0,
         sensitive_headers: set[str] | None = None,
         sensitive_json_fields: set[str] | None = None,
         sensitive_text_patterns: list[str] | None = None,
@@ -190,10 +170,6 @@ class GraphQLClient:
 
         Args:
             endpoint_url: The URL of the GraphQL endpoint.
-            headers: Dictionary of headers for requests. Default is None.
-            verify: Whether to verify SSL certificates. Default is True.
-            timeout: Overall timeout for requests in seconds.
-                     Default is 10.0 seconds.
             sensitive_headers: Set of header names to mask in logs. If None,
                                uses default sensitive headers.
             sensitive_json_fields: Set of JSON field names to mask in logs.
@@ -204,13 +180,11 @@ class GraphQLClient:
                                  Default is True.
             name_logger: Name of the logger to use for logging GraphQL requests.
                          Default is "GraphQLClient".
-            **kwargs: Standard arguments for the `httpx.Client` constructor.
+            **kwargs: Standard arguments for the `httpx.Client` constructor
+                      (e.g., `headers`, `timeout`, `verify`, `cookies`, `proxies`).
         """
         self._endpoint_url = endpoint_url
         self._client = BaseHttpClient(
-            headers=headers,
-            verify=verify,
-            timeout=timeout,
             sensitive_headers=sensitive_headers,
             sensitive_json_fields=sensitive_json_fields,
             sensitive_text_patterns=sensitive_text_patterns,

--- a/qapytest/_config_http.py
+++ b/qapytest/_config_http.py
@@ -20,9 +20,6 @@ class BaseHttpClient(Client):
     def __init__(
         self,
         base_url: str = "",
-        headers: dict[str, str] | None = None,
-        verify: bool = True,
-        timeout: float = 10.0,
         sensitive_headers: set[str] | None = None,
         sensitive_json_fields: set[str] | None = None,
         sensitive_text_patterns: list[str] | None = None,
@@ -32,7 +29,7 @@ class BaseHttpClient(Client):
         **kwargs,
     ) -> None:
         """Constructor for BaseHttpClient."""
-        super().__init__(base_url=base_url, headers=headers, verify=verify, timeout=timeout, **kwargs)
+        super().__init__(base_url=base_url, **kwargs)
         for name in ("httpx", "httpcore", "urllib3"):
             logging.getLogger(name).setLevel(logging.WARNING)
         self._logger = logging.getLogger(name_logger)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -16,7 +16,7 @@ class TestHttpClient:
         client = HttpClient()
         assert isinstance(client, httpx.Client)
         assert client.base_url == ""
-        assert str(client.timeout) == "Timeout(timeout=10.0)"
+        assert str(client.timeout) == "Timeout(timeout=5.0)"
 
     def test_http_client_initialization_with_params(self) -> None:
         """Test HttpClient initialization with custom parameters."""

--- a/uv.lock
+++ b/uv.lock
@@ -950,7 +950,7 @@ wheels = [
 
 [[package]]
 name = "qapytest"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "faker" },


### PR DESCRIPTION
### Changed

- 🌐 **HttpClient** - removed explicit `headers`, `verify`, and `timeout` parameters; they can now be passed directly via `**kwargs` for greater flexibility.
- 📚 **Documentation** - updated HTTP client documentation to reflect the new `**kwargs` approach.
- 📝 **README** - added JSON Query (`find_value`, `find_values`) to the key features section.

### Fixed

- 🧪 **Test updates** - updated test cases to align with the new `HttpClient` parameter interface.